### PR TITLE
Agregar formularios y wizard para creación de fichas de libros

### DIFF
--- a/roles/forms.py
+++ b/roles/forms.py
@@ -1,0 +1,175 @@
+from django import forms
+from django.core.exceptions import ValidationError
+import re
+
+from catalogo.models import LibroFicha, TipoTapa, Moneda, Idioma, Pais
+from roles.models import UsuarioEditorial, Editorial
+
+# ===========================
+# validaciones
+# ===========================
+_ISBN10_RE = re.compile(r"^\d{9}[\dX]$")   # 9 dígitos + dígito o X
+_DIGITS_RE = re.compile(r"^\d+$")
+
+def _normalize_code(raw: str) -> str:
+    """Quita guiones/espacios y pasa a mayúsculas."""
+    return re.sub(r"[\s-]+", "", (raw or "")).upper()
+
+def _is_valid_isbn10(code: str) -> bool:
+    """
+    ISBN-10 con dígito verificador (módulo 11). 'X' equivale a 10.
+    Regla: sum(d_i * w_i) % 11 == 0 con w_i = 10..1
+    """
+    if not _ISBN10_RE.match(code):
+        return False
+    total = 0
+    for i, ch in enumerate(code):           # i = 0..9 -> peso = 10..1
+        weight = 10 - i
+        val = 10 if ch == "X" else int(ch)
+        total += val * weight
+    return total % 11 == 0
+
+def _is_valid_ean13(code: str) -> bool:
+    """
+    EAN-13 / ISBN-13 (módulo 10). Último dígito es verificador.
+    """
+    if len(code) != 13 or not _DIGITS_RE.match(code):
+        return False
+    digits = [int(c) for c in code]
+    checksum = sum(d if (i % 2 == 0) else d * 3 for i, d in enumerate(digits[:-1]))
+    check = (10 - (checksum % 10)) % 10
+    return check == digits[-1]
+
+
+# ===========================
+# Base para los forms del wizard
+# ===========================
+class BaseEditorForm(forms.ModelForm):
+    """
+    - Inyecta request_user para limitar editoriales cuando sea EDITOR.
+    - Homologa mensaje de campo obligatorio.
+    """
+    def __init__(self, *args, **kwargs):
+        self._request_user = kwargs.pop("request_user", None)
+        super().__init__(*args, **kwargs)
+
+        for f in self.fields.values():
+            if f.required:
+                f.error_messages.setdefault("required", "Este campo es obligatorio.")
+
+        if self._request_user is not None:
+            self.limit_editoriales(self._request_user)
+
+    def limit_editoriales(self, user):
+        if hasattr(user, "profile") and getattr(user.profile, "role", None) == "EDITOR":
+            ed_ids = UsuarioEditorial.objects.filter(user=user).values_list("editorial_id", flat=True)
+            if "editorial" in self.fields:
+                self.fields["editorial"].queryset = Editorial.objects.filter(id__in=list(ed_ids))
+
+
+# ===========================
+# PASO 1: Identificación
+# ===========================
+class LibroIdentForm(BaseEditorForm):
+    class Meta:
+        model = LibroFicha
+        fields = [
+            "isbn", "ean", "editorial",
+            "titulo", "subtitulo",
+            "autor", "autor_prologo", "traductor", "ilustrador",
+        ]
+        widgets = {
+            "isbn": forms.TextInput(attrs={
+                "maxlength": 16, "class": "form-control", "required": True,
+                "placeholder": "ISBN-10 o ISBN-13"
+            }),
+            "ean": forms.TextInput(attrs={
+                "maxlength": 16, "class": "form-control",
+                
+            }),
+            "editorial": forms.Select(attrs={"class": "form-select", "required": True}),
+            "titulo": forms.TextInput(attrs={"maxlength": 100, "class": "form-control", "required": True}),
+            "subtitulo": forms.TextInput(attrs={"maxlength": 100, "class": "form-control"}),
+            "autor": forms.TextInput(attrs={"maxlength": 100, "class": "form-control", "required": True}),
+            "autor_prologo": forms.TextInput(attrs={"maxlength": 40, "class": "form-control"}),
+            "traductor": forms.TextInput(attrs={"maxlength": 40, "class": "form-control"}),
+            "ilustrador": forms.TextInput(attrs={"maxlength": 60, "class": "form-control"}),
+        }
+        error_messages = {
+                    'isbn': {
+                        'unique': "ISBN ya existe",
+                        'required': "Campo obligatorio.",
+                    }                      
+                }
+    def clean_isbn(self):
+        raw = self.cleaned_data.get("isbn", "")
+        code = _normalize_code(raw)
+        if len(code) == 10:
+            if not _is_valid_isbn10(code):
+                raise ValidationError("ISBN-10 inválido")
+        elif len(code) == 13:
+            if not _is_valid_ean13(code):
+                raise ValidationError("ISBN-13 inválido")
+        else:
+            raise ValidationError("El ISBN debe tener 10 o 13 caracteres")
+        return code  # se guarda normalizado
+
+    def clean_ean(self):
+        raw = self.cleaned_data.get("ean", "")
+        if not raw:
+            return raw
+        code = _normalize_code(raw)
+        if not _is_valid_ean13(code):
+            raise ValidationError("EAN-13 inválido")
+        return code  # se guarda normalizado
+
+
+# ===========================
+# PASO 2: Ficha técnica
+# ===========================
+class LibroTecnicaForm(BaseEditorForm):
+    class Meta:
+        model = LibroFicha
+        fields = [
+            "tipo_tapa", "numero_paginas",
+            "alto_cm", "ancho_cm", "grosor_cm", "peso_gr",
+            "idioma_original", "numero_edicion", "fecha_edicion",
+            "pais_edicion", "numero_impresion", "tematica",
+        ]
+        widgets = {
+            "tipo_tapa": forms.Select(attrs={"class": "form-select", "required": True}),
+            "numero_paginas": forms.NumberInput(attrs={"class": "form-control", "min": 1, "required": True}),
+            "alto_cm": forms.NumberInput(attrs={"class": "form-control", "step": "0.01"}),
+            "ancho_cm": forms.NumberInput(attrs={"class": "form-control", "step": "0.01"}),
+            "grosor_cm": forms.NumberInput(attrs={"class": "form-control", "step": "0.01"}),
+            "peso_gr": forms.NumberInput(attrs={"class": "form-control"}),
+            "idioma_original": forms.Select(attrs={"class": "form-select", "required": True}),
+            "numero_edicion": forms.NumberInput(attrs={"class": "form-control", "min": 1, "required": True}),
+            "fecha_edicion": forms.DateInput(attrs={"type": "date", "class": "form-control", "required": True}),
+            "pais_edicion": forms.Select(attrs={"class": "form-select", "required": True}),
+            "numero_impresion": forms.NumberInput(attrs={"class": "form-control"}),
+            "tematica": forms.TextInput(attrs={"maxlength": 60, "class": "form-control"}),
+        }
+
+
+# ===========================
+# PASO 3: Comercial
+# ===========================
+class LibroComercialForm(BaseEditorForm):
+    class Meta:
+        model = LibroFicha
+        fields = ["precio", "moneda", "descuento_distribuidor", "resumen_libro", "codigo_imagen", "rango_etario"]
+        widgets = {
+            "precio": forms.NumberInput(attrs={"class": "form-control", "step": "0.01", "required": True}),
+            "moneda": forms.Select(attrs={"class": "form-select", "required": True}),
+            "descuento_distribuidor": forms.NumberInput(attrs={"class": "form-control", "step": "0.1", "required": True}),
+            "resumen_libro": forms.Textarea(attrs={"class": "form-control", "rows": 6, "required": True}),
+            "codigo_imagen": forms.TextInput(attrs={"maxlength": 120, "class": "form-control"}),
+            "rango_etario": forms.TextInput(attrs={"maxlength": 30, "class": "form-control"}),
+        }
+
+    def clean_descuento_distribuidor(self):
+        val = self.cleaned_data.get("descuento_distribuidor")
+        if val is None or not (0 <= float(val) <= 99.9):
+            raise ValidationError("El descuento debe estar entre 0.0 y 99.9%.")
+        return val

--- a/roles/urls.py
+++ b/roles/urls.py
@@ -7,17 +7,19 @@
 
 from django.urls import path
 from .views import (
-    PanelView, LibroCreateView, LibroEditView
-    
+    PanelView,                 # panel unificado
+    LibroCreateWizardView,     # wizard de creación de fichas en tres pasos
+    LibroEditView,             # editar (para los templates de edición)
+    ficha_upload # solo para probar carga archivo (validar posteriormente)
 )
 
 app_name = "roles"
 
 urlpatterns = [
-    # Ruta única del panel (sirve para ADMIN / EDITOR / CONSULTOR)
     path("panel/", PanelView.as_view(), name="panel"),
 
-    # Editor: crear/editar (stubs)
-    path("editor/fichas/nueva/",        LibroCreateView.as_view(), name="ficha_new"),
-    path("editor/fichas/<str:isbn>/",   LibroEditView.as_view(),   name="ficha_edit"),
+    # Wizard de creación (EDITOR)
+    path("editor/fichas/nueva/",      LibroCreateWizardView.as_view(), name="ficha_new"),
+    path("editor/fichas/<str:isbn>/", LibroEditView.as_view(),         name="ficha_edit"),
+    path("editor/fichas/cargar/", ficha_upload, name="ficha_upload"),
 ]

--- a/static/js/wizard_validacion.js
+++ b/static/js/wizard_validacion.js
@@ -1,0 +1,218 @@
+
+(function () {
+  const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+  // norm: limpia espacios/guiones y pasa a MAYÚSCULAS (útil para validar códigos)
+  const norm = s => (s || "").toString().replace(/[\s-]+/g, "").toUpperCase();
+
+  function ensureFeedbackEl(input) {
+    // Busca un .invalid-feedback cercano; si no existe, lo crea
+    let container = input.closest('.col-md-4, .col-md-6, .col-12') || input.parentElement;
+    if (!container) container = input;
+    let fb = container.querySelector('.invalid-feedback');
+    if (!fb) {
+      fb = document.createElement('div');
+      fb.className = 'invalid-feedback d-block';
+      container.appendChild(fb);
+    }
+    return fb;
+  }
+
+  // showError: marca el input como inválido y escribe el mensaje
+  function showError(input, msg) {
+    input.classList.add('is-invalid');
+    const fb = ensureFeedbackEl(input);
+    fb.textContent = msg;
+  }
+  // clearError: limpia el estado de error del input (y borra el texto del feedback)
+  function clearError(input) {
+    input.classList.remove('is-invalid');
+    const container = input.closest('.col-md-4, .col-md-6, .col-12') || input.parentElement;
+    const fb = container ? container.querySelector('.invalid-feedback') : null;
+    if (fb) fb.textContent = '';
+  }
+
+   // === Validadores específicos (cálculo de dígitos verificadores) ===
+   // ISBN-10: 9 números + dígito (puede ser X). Fórmula estándar mod 11.
+  function isValidISBN10(code) {
+    if (!/^\d{9}[\dX]$/.test(code)) return false;
+    let sum = 0;
+    for (let i = 0; i < 10; i++) {
+      const ch = code[i] === 'X' ? 10 : parseInt(code[i], 10);
+      sum += ch * (10 - i);
+    }
+    return sum % 11 === 0;
+  }
+  // EAN-13 (también sirve para ISBN-13): checksum con pesos 1/3 alternados
+  function isValidEAN13(code) {
+    if (!/^\d{13}$/.test(code)) return false;
+    const digits = code.split('').map(Number);
+    const checksum = digits.slice(0, 12).reduce((acc, d, i) => acc + d * (i % 2 ? 3 : 1), 0);
+    const check = (10 - (checksum % 10)) % 10;
+    return check === digits[12];
+  }
+
+  // === Reglas de validación por campo (según "name") ===
+  async function validateField(input) {
+    const name = input.name;
+    const val = input.value;
+
+    // ---- Paso 1: Identificación ----
+    if (name === 'isbn') {
+      const code = norm(val);
+      if (!code) return showError(input, 'Este campo es obligatorio.'), false;
+      if (code.length === 10) {
+        if (!isValidISBN10(code)) return showError(input, 'ISBN-10 inválido'), false;
+      } else if (code.length === 13) {
+        if (!isValidEAN13(code)) return showError(input, 'ISBN-13 inválido'), false;
+      } else {
+        return showError(input, 'ISBN debe tener 10 o 13 caracteres.'), false;
+      }
+      return clearError(input), true;
+    }
+    if (name === 'ean') {
+      const code = norm(val);
+      if (!code) return clearError(input), true; // opcional
+      if (!isValidEAN13(code)) return showError(input, 'EAN inválido'), false;
+      return clearError(input), true;
+    }
+    if (name === 'editorial') {
+      if (!val) return showError(input, 'Campo obligatorio.'), false;
+      return clearError(input), true;
+    }
+    if (name === 'titulo' || name === 'autor') {
+      if (!val.trim()) return showError(input, 'Campo obligatorio.'), false;
+      return clearError(input), true;
+    }
+
+    // ---- Paso 2: Ficha técnica ----
+    if (name === 'tipo_tapa' || name === 'idioma_original' || name === 'pais_edicion') {
+      if (!val) return showError(input, 'Campo obligatorio.'), false;
+      return clearError(input), true;
+    }
+    if (name === 'numero_paginas' || name === 'numero_edicion') {
+      if (!val) return showError(input, 'Campo obligatorio.'), false;
+      const n = Number(val);
+      if (!Number.isInteger(n) || n < 1) return showError(input, 'Número entero ≥ 1.'), false;
+      return clearError(input), true;
+    }
+    if (name === 'fecha_edicion') {
+      if (!val) return showError(input, 'Campo obligatorio'), false;
+      return clearError(input), true;
+    }
+    // Son opcionales: si vienen, deben ser números >= 0
+    if (name === 'alto_cm' || name === 'ancho_cm' || name === 'grosor_cm') {
+      if (!val) return clearError(input), true;
+      const n = Number(val);
+      if (!Number.isFinite(n) || n < 0) return showError(input, 'Número ≥ 0).'), false;
+      return clearError(input), true;
+    }
+    if (name === 'peso_gr') {
+      if (!val) return clearError(input), true;
+      const n = Number(val);
+      if (!Number.isInteger(n) || n < 0) return showError(input, 'Número entero ≥ 0).'), false;
+      return clearError(input), true;
+    }
+
+    // ---- Paso 3: Comercial ----
+    if (name === 'precio') {
+      if (!val) return showError(input, 'Campo obligatorio.'), false;
+      const n = Number(val);
+      if (!Number.isFinite(n) || n < 0) return showError(input, 'Ingrese un precio ≥ 0'), false;
+      return clearError(input), true;
+    }
+    if (name === 'moneda') {
+      if (!val) return showError(input, 'Campo obligatorio.'), false;
+      return clearError(input), true;
+    }
+    if (name === 'descuento_distribuidor') {
+      if (!val) return showError(input, 'Campo obligatorio.'), false;
+      const n = Number(val);
+      if (!Number.isFinite(n) || n < 0 || n > 99.9) return showError(input, 'Descuento debe estar entre 0.0 y 99.9%.'), false;
+      return clearError(input), true;
+    }
+    if (name === 'resumen_libro') {
+      if (!val.trim()) return showError(input, 'Campo obligatorio.'), false;
+      return clearError(input), true;
+    }
+
+    // Cualquier otro campo (normalmente opcional): limpio y doy OK
+    return clearError(input), true;
+  }
+
+  // === Enlaces de eventos (bindings) ===
+  const form = document.getElementById('wizardForm');
+  if (!form) return; // Si no hay form en la página, no hago nada
+
+  // cuando el usuario sale del campo, valido y muestro error si corresponde
+  form.addEventListener('blur', (e) => {
+    if (e.target && e.target.name) validateField(e.target);
+  }, true);
+
+  // input: si el campo estaba inválido, revalido al teclear para limpiar apenas esté bien
+  form.addEventListener('input', (e) => {
+    if (e.target && e.target.classList.contains('is-invalid')) {
+      validateField(e.target); // revalida y limpia si ya es OK
+    }
+  });
+
+  // submit: antes de enviar, valido todo el formulario; si algo falla, detengo envío
+  form.addEventListener('submit', async (e) => {
+    const fields = $$('input, select, textarea', form).filter(el => el.name);
+    let ok = true;
+    for (const el of fields) {
+      const valid = await validateField(el);
+      if (!valid) ok = false;
+    }
+    if (!ok) {
+      e.preventDefault();
+      e.stopPropagation();
+      const firstBad = form.querySelector('.is-invalid');
+      if (firstBad) firstBad.focus();
+    }
+  });
+
+
+
+
+
+
+ (function () {
+    const btn = document.getElementById('btnPickImg');
+    const fileInput = document.getElementById('pickImgInput');
+    const hiddenCodigo = document.getElementById('id_codigo_imagen');
+    const namePreview = document.getElementById('pickImgName');
+
+    // ISBN guardado en sesión (paso Ident del wizard)
+    const ISBN_FROM_SESSION = "{{ wizard_data.ident.isbn|default:'' }}";
+
+    if (btn && fileInput && hiddenCodigo && namePreview) {
+      btn.addEventListener('click', () => fileInput.click());
+
+      fileInput.addEventListener('change', function () {
+        if (!this.files || !this.files.length) return;
+
+        const fname = this.files[0].name || "";
+        namePreview.textContent = fname;
+
+        const ext = (fname.split('.').pop() || "").toLowerCase();
+        if (!['png', 'jpg', 'jpeg'].includes(ext)) {
+          alert("Formato no permitido. Usa PNG, JPG o JPEG.");
+          this.value = "";
+          namePreview.textContent = "";
+          hiddenCodigo.value = ""; // la vista usará ISBN.png si queda vacío
+          return;
+        }
+
+        const base =
+          (ISBN_FROM_SESSION || "").trim() ||
+          (hiddenCodigo.value.includes('.') ? hiddenCodigo.value.split('.')[0] : "") ||
+          "ISBN";
+
+        const normalizedExt = (ext === 'jpeg') ? 'jpg' : ext;
+        hiddenCodigo.value = `${base}.${normalizedExt}`;
+      });
+    }
+  })();
+
+  
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -61,8 +61,13 @@ Plantilla base de Liberalia:
     </div>
   </nav>
 
+  <!--direccionar al logo para que al presionar vuelva al panel principal con tamaños fijo de 200px-->
   <div class="hero-section">
-    <img src="{% static 'img/logo_liberalia.jpg' %}" class="hero-image" alt="Logo liberalia">
+    <a href="{% if user.is_authenticated %}{% url 'roles:panel' %}{% else %}{% url 'home-root' %}{% endif %}"
+      class="d-inline-block" style="line-height:0;">
+      <img src="{% static 'img/logo_liberalia.jpg' %}" alt="Logo liberalia"
+        style="height: 200px; width:auto; display:block;">
+    </a>
   </div>
   {% endif %}
 

--- a/templates/catalogo/libro_detalle.html
+++ b/templates/catalogo/libro_detalle.html
@@ -7,7 +7,7 @@
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="h4 mb-0">Ficha del libro</h1>
     <div class="d-print-none">
-      <a class="btn btn-outline-secondary" href="{% url 'roles:panel_consultor' %}">Volver</a>
+      <a class="btn btn-outline-secondary" href="{% url 'roles:panel' %}">Volver</a>
       <button class="btn btn-secondary" onclick="window.print()">Imprimir</button>
     </div>
   </div>

--- a/templates/roles/libro_wizard.html
+++ b/templates/roles/libro_wizard.html
@@ -1,0 +1,339 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Crear ficha – Liberalia{% endblock %}
+
+{% block content %}
+<div class="container py-3" style="max-width:980px; margin:0 auto;">
+
+  <!-- Título y botón cargar archivo -->
+  <div class="position-relative mb-3" style="min-height:2.25rem;">
+    <h4 class="m-0 text-center">Crear Nueva Ficha</h4>
+
+    <!-- Botón “Cargar archivo” -->
+    <form id="uploadForm" method="post" enctype="multipart/form-data" action="{% url 'roles:ficha_upload' %}"
+      class="position-absolute top-50 end-0 translate-middle-y d-inline">
+      {% csrf_token %}
+      <input type="hidden" name="step" value="{{ step }}">
+      <input type="file" name="archivo" id="archivoInput" class="d-none" accept=".xlsx,.csv,.json,.txt">
+      <button type="button" class="btn btn-outline-primary btn-sm"
+        onclick="document.getElementById('archivoInput').click()">
+        Cargar archivo
+      </button>
+    </form>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <!-- Formulario único para todo el “wizard” -->
+      <form id="wizardForm" method="post" class="row g-3" novalidate>
+        {% csrf_token %}
+        <!-- Paso actual del flujo (ident / tecnica / comercial). Lo mando en cada submit para no perder el hilo -->
+        <input type="hidden" name="step" value="{{ step }}" />
+
+        {% if step == "ident" %}
+
+        <!-- PASO 1: Datos básicos del libro -->
+        <h5 class="mb-3 text-uppercase text-muted fw-bold">Identificación del libro</h5>
+
+        <!-- Campo + bloque de errores (si el backend marca algo inválido, lo muestro debajo) -->
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">ISBN (*)</label>
+          {{ form.isbn }}
+          {% if form.isbn.errors %}
+          <div class="invalid-feedback d-block">{{ form.isbn.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">EAN-13</label>
+          {{ form.ean }}
+          {% if form.ean.errors %}
+          <div class="invalid-feedback d-block">{{ form.ean.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Sello Editorial (*)</label>
+          {{ form.editorial }}
+          {% if form.editorial.errors %}
+          <div class="invalid-feedback d-block">{{ form.editorial.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label fw-bold text-muted small">Título del Libro (*)</label>
+          {{ form.titulo }}
+          {% if form.titulo.errors %}
+          <div class="invalid-feedback d-block">{{ form.titulo.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label fw-bold text-muted small">Subtítulo</label>
+          {{ form.subtitulo }}
+          {% if form.subtitulo.errors %}
+          <div class="invalid-feedback d-block">{{ form.subtitulo.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <!-- Autores y Prólogo todos con el mismo patrón de errores -->
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Autor(es) (*)</label>
+          {{ form.autor }}
+          {% if form.autor.errors %}
+          <div class="invalid-feedback d-block">{{ form.autor.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Autor del Prólogo</label>
+          {{ form.autor_prologo }}
+          {% if form.autor_prologo.errors %}
+          <div class="invalid-feedback d-block">{{ form.autor_prologo.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Traductor(es)</label>
+          {{ form.traductor }}
+          {% if form.traductor.errors %}
+          <div class="invalid-feedback d-block">{{ form.traductor.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Ilustrador(es)</label>
+          {{ form.ilustrador }}
+          {% if form.ilustrador.errors %}
+          <div class="invalid-feedback d-block">{{ form.ilustrador.errors|striptags }}</div>
+          {% endif %}
+        </div>
+        {% endif %}
+
+        {% if step == "tecnica" %}
+
+        <!-- PASO 2: Especificaciones técnicas del libro (formato, páginas, idioma, medidas) -->
+        <h5 class="mb-3 text-uppercase text-muted fw-bold">Ficha Técnica</h5>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Encuadernación (*)</label>
+          {{ form.tipo_tapa }}
+          {% if form.tipo_tapa.errors %}
+          <div class="invalid-feedback d-block">{{ form.tipo_tapa.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Cant. de páginas (*)</label>
+          {{ form.numero_paginas }}
+          {% if form.numero_paginas.errors %}
+          <div class="invalid-feedback d-block">{{ form.numero_paginas.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Idioma (*)</label>
+          {{ form.idioma_original }}
+          {% if form.idioma_original.errors %}
+          <div class="invalid-feedback d-block">{{ form.idioma_original.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <!-- Medidas del libro (opcionales, pero útiles para tener la ficha completa) -->
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Alto (cm)</label>
+          {{ form.alto_cm }}
+          {% if form.alto_cm.errors %}
+          <div class="invalid-feedback d-block">{{ form.alto_cm.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Ancho (cm)</label>
+          {{ form.ancho_cm }}
+          {% if form.ancho_cm.errors %}
+          <div class="invalid-feedback d-block">{{ form.ancho_cm.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Grosor (cm)</label>
+          {{ form.grosor_cm }}
+          {% if form.grosor_cm.errors %}
+          <div class="invalid-feedback d-block">{{ form.grosor_cm.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Peso (gr)</label>
+          {{ form.peso_gr }}
+          {% if form.peso_gr.errors %}
+          <div class="invalid-feedback d-block">{{ form.peso_gr.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <!-- Datos de edición -->
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Nº edición (*)</label>
+          {{ form.numero_edicion }}
+          {% if form.numero_edicion.errors %}
+          <div class="invalid-feedback d-block">{{ form.numero_edicion.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Fecha edición (*)</label>
+          {{ form.fecha_edicion }}
+          {% if form.fecha_edicion.errors %}
+          <div class="invalid-feedback d-block">{{ form.fecha_edicion.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label fw-bold text-muted small">País edición (*)</label>
+          {{ form.pais_edicion }}
+          {% if form.pais_edicion.errors %}
+          <div class="invalid-feedback d-block">{{ form.pais_edicion.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label fw-bold text-muted small">Nº de Impresión</label>
+          {{ form.numero_impresion }}
+          {% if form.numero_impresion.errors %}
+          <div class="invalid-feedback d-block">{{ form.numero_impresion.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-6">
+          <label class="form-label fw-bold text-muted small">Temática</label>
+          {{ form.tematica }}
+          {% if form.tematica.errors %}
+          <div class="invalid-feedback d-block">{{ form.tematica.errors|striptags }}</div>
+          {% endif %}
+        </div>
+        {% endif %}
+
+        {% if step == "comercial" %}
+
+        <!-- PASO 3: Info comercial (precio, moneda, descuento, resumen) -->
+        <h5 class="mb-3 text-uppercase text-muted fw-bold">Comercial</h5>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Precio sin IVA (*)</label>
+          {{ form.precio }}
+          {% if form.precio.errors %}
+          <div class="invalid-feedback d-block">{{ form.precio.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Moneda (*)</label>
+          {{ form.moneda }}
+          {% if form.moneda.errors %}
+          <div class="invalid-feedback d-block">{{ form.moneda.errors|striptags }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-md-4">
+          <label class="form-label fw-bold text-muted small">Desc. distribuidor (%) (*)</label>
+          {{ form.descuento_distribuidor }}
+          {% if form.descuento_distribuidor.errors %}
+          <div class="invalid-feedback d-block">{{ form.descuento_distribuidor.errors|striptags }}</div>
+          {% endif %}
+          {% if form.descuento_distribuidor.help_text %}
+          <div class="form-text">{{ form.descuento_distribuidor.help_text }}</div>
+          {% endif %}
+        </div>
+
+        <div class="col-12">
+          <label class="form-label fw-bold text-muted small">Resumen del libro (*)</label>
+          {{ form.resumen_libro }}
+          {% if form.resumen_libro.errors %}
+          <div class="invalid-feedback d-block">{{ form.resumen_libro.errors|striptags }}</div>
+          {% endif %}
+        </div>
+        <br>
+
+        <div class="col-12 mt-2">
+          <div class="row g-3 align-items-end">
+
+            <!-- IZQUIERDA: Portada -->
+            <div class="col-md-6 d-flex flex-column">
+              <label class="form-label fw-bold text-muted small">Portada (*)</label>
+
+              <div class="d-flex align-items-center mt-1">
+                <button type="button" class="btn btn-secondary btn-sm"
+                  onclick="document.getElementById('pickImgInput').click()">
+                  Seleccionar archivo
+                </button>
+                <span class="ms-2" id="file-name">Sin archivos seleccionados</span>
+              </div>
+
+              <input type="file" id="pickImgInput" name="portada" class="d-none"
+                accept=".png,.jpg,.jpeg,image/png,image/jpeg"
+                onchange="document.getElementById('file-name').textContent = this.files[0]?.name || 'Sin archivos seleccionados'">
+
+              <input type="hidden" name="codigo_imagen" id="id_codigo_imagen"
+                value="{{ form.codigo_imagen.value|default:'' }}">
+            </div>
+
+            <!-- DERECHA: Rango etario -->
+            <div class="col-md-6">
+              <label for="{{ form.rango_etario.id_for_label }}" class="form-label fw-bold text-muted small">Rango etario</label>
+              {{ form.rango_etario }}
+              {% if form.rango_etario.errors %}
+              <div class="invalid-feedback d-block">{{ form.rango_etario.errors|striptags }}</div>
+              {% endif %}
+            </div>
+
+          </div>
+        </div>
+
+        {% endif %}
+
+        <!-- Botonera de navegación entre pasos -->
+        <div class="d-flex w-100 align-items-center position-relative mt-3">
+
+          <!-- Botón anterior / espaciador -->
+          {% if step != "ident" %}
+          <button name="prev" class="btn btn-outline-primary" type="submit">← Anterior</button>
+          {% else %}
+          <span style="width: 110px;"></span> <!-- mismo ancho que el botón para mantener la simetría -->
+          {% endif %}
+
+          <!-- Texto centrado informando campos obligatorios -->
+          <div class="position-absolute start-50 translate-middle-x text-muted small fw-bold">
+            (*) campos obligatorios
+          </div>
+
+          <!-- Botón siguiente / guardar -->
+          {% if step != "comercial" %}
+          <button class="btn btn-primary ms-auto" type="submit">Continuar →</button>
+          {% else %}
+          <button class="btn btn-primary ms-auto" type="submit">Guardar</button>
+          {% endif %}
+        </div>
+
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- JS de validación para mostrar errores al instante en los campos obligatorios -->
+<script src="{% static 'js/wizard_validacion.js' %}?v=2"></script>
+<script>
+  // Envía automáticamente cuando el usuario elige un archivo
+  (function () {
+    const input = document.getElementById('archivoInput');
+    const form = document.getElementById('uploadForm');
+    if (input && form) {
+      input.addEventListener('change', function () {
+        if (this.files && this.files.length) form.submit();
+      });
+    }
+  })();
+</script>
+
+{% endblock %}

--- a/templates/roles/panel.html
+++ b/templates/roles/panel.html
@@ -28,7 +28,7 @@ PANEL UNIFICADO (ADMIN / CONSULTOR / EDITOR)
   }
 
   .input-group .form-control {
-    padding-right: 1rem;    
+    padding-right: 1rem;
   }
 </style>
 
@@ -192,7 +192,7 @@ PANEL UNIFICADO (ADMIN / CONSULTOR / EDITOR)
           <td>{{ r.fecha_edicion|date:"d/m/Y" }}</td>
           <td class="text-end">
             {% if can_edit and edit_url_name %}
-            <a class="btn btn-sm btn-outline-primary" href="{% url edit_url_name r.isbn %}" >Editar</a>
+            <a class="btn btn-sm btn-outline-primary" href="{% url edit_url_name r.isbn %}">Editar</a>
             {% elif show_detail %}
             <!--<a href="{% url 'catalogo:libro_detalle' r.isbn %}" class="btn btn-sm btn-outline-burdeo {{ detail_disabled|default:'disabled' }}">Detalle</a>-->
             <a class="btn btn-sm btn-outline-burdeo" href="{% url 'catalogo:libro_detalle' r.isbn %}">Detalle</a>
@@ -209,8 +209,43 @@ PANEL UNIFICADO (ADMIN / CONSULTOR / EDITOR)
       </tbody>
     </table>
   </div>
-</div>
 
+  <!--PAGINACION (8 REGISTROS POR)-->
+  {% if is_paginated %}
+  <nav aria-label="Paginación" class="d-flex justify-content-center mt-3">
+    <ul class="pagination mb-0">
+
+      {% if page_obj.has_previous %}
+      <li class="page-item">
+        <a class="page-link"
+          href="?{% if base_qs %}{{ base_qs }}&{% endif %}page={{ page_obj.previous_page_number }}">&laquo;</a>
+      </li>
+      {% else %}
+      <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+      {% endif %}
+
+      {% for num in paginator.page_range %}
+      {% if page_obj.number == num %}
+      <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+      {% elif num > page_obj.number|add:"-3" and num < page_obj.number|add:"3" %} <li class="page-item">
+        <a class="page-link" href="?{% if base_qs %}{{ base_qs }}&{% endif %}page={{ num }}">{{ num }}</a>
+        </li>
+        {% endif %}
+        {% endfor %}
+
+        {% if page_obj.has_next %}
+        <li class="page-item">
+          <a class="page-link"
+            href="?{% if base_qs %}{{ base_qs }}&{% endif %}page={{ page_obj.next_page_number }}">&raquo;</a>
+        </li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+        {% endif %}
+
+    </ul>
+  </nav>
+  {% endif %}
+</div>
 
 <script>
   const form = document.querySelector('form');


### PR DESCRIPTION
NUEVOS ARCHIVOS:

1. roles/forms.py: formularios para crear fichas de libros
2. templates/roles/libro_wizard.html: template para creación de fichas en tres pasos
3. static/js/wizard_validacion.js: validación de campos obligatorios y de ISBN/EAN

MODIFICADOS:

1. roles/urls.py: agregado ficha_upload para carga de imagen de portada (modo prueba)
2. roles/views.py: agregada clase LibroCreateWizardView y funciones asociadas. Incluye dos clases provisionales a reemplazar: edición de fichas y carga masiva
3. templates/catalogo/libro_detalle.html: actualizado link de “Volver” a roles:panel (antes apuntaba a roles:panel_consultor que ya no existe)
4. Incluir paginación en despliegue de registros (8 por página) en templates/panel.html y BasePanelView
- Redirigir al panel al presionar logo_liberalia